### PR TITLE
Allow local web control

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -13,8 +13,16 @@ class Client extends Sock {
     let peer = util.parse_peer_address(address)
     if (!peer) throw 'Invalid peer address "' + address + "'"
 
-    let host = peer.host || default_host
-    let port = peer.port || default_port
+    let hostname = window.location.hostname
+    var def_host = default_host
+    var def_port = default_port
+    if (!hostname.endsWith('foldingathome.org')) {
+      def_host = hostname
+      def_port = window.location.port
+    }
+
+    let host = peer.host || def_host
+    let port = peer.port || def_port
     let path = peer.path || ''
 
     let url = 'ws://' + host + ':' + port + '/api/websocket' + path


### PR DESCRIPTION
If not https://*foldingathome.org/ use default host:port from window.location, not 127.0.0.1:7396 for the client connection.

This allows people to use an unmodified local web control vended by fah-client web-root.

Such is useful if someone wants to use Safari, or a phone/tablet browser.

Even things like team name lookup work properly.
(With a previous hack, team would appear as a number.)

Edit: if not localhost, some lookups like team break. See javascript console for errors.

Edit2:
`http://localhost:7396` works perfectly.
`http://127.0.0.1:7396` works perfectly.
`http://mycomputer.local:7396` works ok, minor deficits.
All such origins require editing fah-client `config.xml` `allowed-origins`, `http-addresses`, and `web-root`.

Edit3: the code does not care if the protocol is not `https`.

See also #58
