### PR TITLE
Add SConstruct for dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 node_modules
 .DS_Store
-dist
+/dist
+/dist.txt
+/*.tar.bz2
 *~
 /package-lock.json
+/.sconsign.dblite
+/.sconf_temp
+/config.log

--- a/SConstruct
+++ b/SConstruct
@@ -1,0 +1,33 @@
+import os
+import json
+env = Environment(ENV = os.environ)
+try:
+  paths = [os.environ.get('CBANG_HOME'), os.environ.get('CBANG_CONFIG_HOME')]
+  env.Tool('config', toolpath = paths)
+except Exception as e:
+  raise Exception('CBANG_HOME not set?\n' + str(e))
+
+env.CBLoadTools('dist packager')
+conf = env.CBConfigure()
+
+with open('package.json', 'r') as f: package_info = json.load(f)
+
+version = package_info['version']
+env.Replace(PACKAGE_VERSION = version)
+env.Replace(dist_build = '')
+conf.Finish()
+
+if 'dist' in COMMAND_LINE_TARGETS:
+  if not env.GetOption('clean'):
+    env.RunCommandOrRaise(['npm', 'install'])
+    env.RunCommandOrRaise(['npm', 'run', 'build'])
+
+  distfiles = ['dist', 'LICENSE']
+  tar = env.TarBZ2Dist('web-control', distfiles)
+  AlwaysBuild(tar)
+  Alias('dist', tar)
+  Clean(tar, ['dist', 'dist.txt'])
+
+if 'distclean' in COMMAND_LINE_TARGETS:
+  Clean('distclean', ['.sconsign.dblite', '.sconf_temp', 'config.log',
+    Glob('*.tar.bz2'), 'dist', 'dist.txt'])

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fah-web-client-bastet",
-  "version": "0.0.1",
+  "version": "8.1.12",
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
`scons dist` creates `web-control_{version}.tar.bz2`.

Instead of making `cbang` a submodule, there will be a no-build `cbang-config` in `fah-build`.
