### PR TITLE
Support remote browser with local web control

### DIFF
--- a/src/LocationDialog.vue
+++ b/src/LocationDialog.vue
@@ -28,6 +28,7 @@
 
 <script>
 
+import util from './util.js'
 
 export default {
   data() {
@@ -50,8 +51,8 @@ export default {
 
 
     open(cb) {
-      const host = localStorage.getItem('client-host') || '127.0.0.1'
-      const port = localStorage.getItem('client-port') || 7396
+      const host = util.default_host()
+      const port = util.default_port()
       this.location = host + ':' + port
 
       this.$refs.dialog.open(result => {

--- a/src/client.js
+++ b/src/client.js
@@ -30,8 +30,8 @@ import {reactive, watchEffect} from 'vue'
 import Sock   from './sock.js'
 import util   from './util.js'
 
-const default_host = localStorage.getItem('client-host') || '127.0.0.1'
-const default_port = localStorage.getItem('client-port') || 7396
+const default_host = util.default_host()
+const default_port = util.default_port()
 
 
 class Client extends Sock {

--- a/src/util.js
+++ b/src/util.js
@@ -82,6 +82,25 @@ export default {
   },
 
 
+  default_host() {
+    let hostname = window.location.hostname
+    var lhost = null
+    if (hostname.endsWith('.local')) lhost = hostname
+    const host = localStorage.getItem('client-host') || lhost || '127.0.0.1'
+    return host
+  },
+
+
+  default_port() {
+    let hostname = window.location.hostname
+    var lport = null
+    if (hostname.endsWith('.local') || hostname == 'localhost')
+      lport = window.location.port
+    const port = localStorage.getItem('client-port') || lport || 7396
+    return port
+  },
+
+
   update(data, update) {
     let i = 0
 


### PR DESCRIPTION
Add util default_host(), default_port()
If location is *.local, use that as default host, port when not set in localStorage

This partly addresses #58, at least for a local web control.

It does not address need to support mobile browsers via https://app.foldingathome.org/

Works as-is for local web control, without user hacking.

Still has the usual fallback to 127.0.0.1 and/or 7396.

Covers non-standard port if host is *.local or localhost.
