### PR TITLE
Support remote browser to local web control, again

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,7 @@ async function main(url) {
 
   console.debug({account: Object.assign({}, ctx.$adata)})
 
-  new DirectMachConn(ctx, 'local', '127.0.0.1:7396')
+  new DirectMachConn(ctx, 'local', util.default_address())
 
   app.use(router)
   app.component('Button',        Button)

--- a/src/util.js
+++ b/src/util.js
@@ -334,4 +334,13 @@ export default {
     if (type != 'gzip') throw 'Unsupported compression type "' + type + '"'
     return this.buf2str(ungzip(this.str2buf(s)))
   },
+
+
+  default_address() {
+    let hostname = window.location.hostname
+    let host     = hostname.endsWith('.local') ? hostname : '127.0.0.1'
+    let local    = hostname.endsWith('.local') || hostname == 'localhost'
+    let port     = local ? window.location.port : 7396
+    return host + ':' + port
+  },
 }


### PR DESCRIPTION
Re-implements optional feature introduced by #99
