### PR TITLE
Rename to Web Control in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Folding@home Web Client Changelog
+Folding@home Web Control Changelog
 =================================
 
 ## v8.2.2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Folding@home Bastet Web Client
-==============================
+Folding@home Bastet Web Control
+===============================
 
 This is the frontend Web app for the Folding@home v8 client, codenamed Bastet.
 See Also: https://github.com/FoldingAtHome/fah-client-bastet

--- a/src/account.js
+++ b/src/account.js
@@ -145,7 +145,7 @@ class Account {
     //  2. J = RSA-OAEP.import(machine.pubkey)
     //  3. M = J.encrypt(E)
     //  4. N = K.sign(M)
-    //  5. Web client sends M and N to machine via the node.
+    //  5. Web control sends M and N to machine via the node.
     //  6. Machine checks signature N is valid for M.
     //  7. Machine computes E = RSA-OAEP.import(machine.prikey).decrypt(M)
     //  8. Communication proceeds with messages encrypted with E.


### PR DESCRIPTION
Rename for consistency with other docs.
Some, such as lar.systems, are referring to the front end as Web Client.
