### PR TITLE
Add thead and tbody elements where required

### DIFF
--- a/src/AccountTeams.vue
+++ b/src/AccountTeams.vue
@@ -118,33 +118,35 @@ fieldset.settings.view-panel.account-teams
 
   div(v-if="!teams.length") You do not currently own any F@H teams.
   table.view-table(v-else)
-    tr
-      th.team-logo Logo
-      th.team-id Team
-      th.team-name Name
-      th.team-wus WUs
-      th.team-score Score
-      th.team-actions Actions
+    thead
+      tr
+        th.team-logo Logo
+        th.team-id Team
+        th.team-name Name
+        th.team-wus WUs
+        th.team-score Score
+        th.team-actions Actions
 
-    tr(v-for="team in teams")
-      td.team-logo: img(:src="team.logo")
+    tbody
+      tr(v-for="team in teams")
+        td.team-logo: img(:src="team.logo")
 
-      td.team-id
-        a(:href="`${$stats.url}/team/${team.team}`", target="_blank")
-          | {{team.team}}
+        td.team-id
+          a(:href="`${$stats.url}/team/${team.team}`", target="_blank")
+            | {{team.team}}
 
-      td.team-name: component(:href="team.url", target="_blank",
-        :is="team.url ? 'a' : 'span'") {{team.name}}
+        td.team-name: component(:href="team.url", target="_blank",
+          :is="team.url ? 'a' : 'span'") {{team.name}}
 
-      td.team-wus {{(team.wus || 0).toLocaleString()}}
-      td.team-score {{(team.score || 0).toLocaleString()}}
+        td.team-wus {{(team.wus || 0).toLocaleString()}}
+        td.team-score {{(team.score || 0).toLocaleString()}}
 
-      td.team-actions
-        div
-          Button.button-icon(icon="trash", @click="delete_team(team)",
-            title="Delete team.", :disabled="!!team.wus")
-          Button.button-icon(icon="pencil", @click="edit_team(team)",
-            title="Edit team settings.")
+        td.team-actions
+          div
+            Button.button-icon(icon="trash", @click="delete_team(team)",
+              title="Delete team.", :disabled="!!team.wus")
+            Button.button-icon(icon="pencil", @click="edit_team(team)",
+              title="Edit team settings.")
 
   .actions
     Button(text="New Team", icon="plus", @click="create_team",

--- a/src/GroupSettings.vue
+++ b/src/GroupSettings.vue
@@ -103,18 +103,20 @@ fieldset.settings.view-panel
 
 
     table.gpus-input.view-table
-      tr
-        th Description
-        th Enabled
+      thead
+        tr
+          th Description
+          th Enabled
 
-      tr.gpu-row(v-for="gpu in gpus",
-        :class="{unsupported: !gpu.supported}",
-        :title="gpu.supported ? `${gpu.id} ${gpu.description}` : \
-          'Unsupported GPU'")
-        td.gpu-description {{gpu.description}}
+      tbody
+        tr.gpu-row(v-for="gpu in gpus",
+          :class="{unsupported: !gpu.supported}",
+          :title="gpu.supported ? `${gpu.id} ${gpu.description}` : \
+            'Unsupported GPU'")
+          td.gpu-description {{gpu.description}}
 
-        td.gpu-enabled
-          input(type="checkbox", v-model="config.gpus[gpu.id].enabled")
+          td.gpu-enabled
+            input(type="checkbox", v-model="config.gpus[gpu.id].enabled")
 
 fieldset.settings.view-panel(v-if="advanced")
   legend

--- a/src/MachinesView.vue
+++ b/src/MachinesView.vue
@@ -69,30 +69,33 @@ export default {
         <!--plot-view(:x="$machs.ppd", :min="1000000")-->
 
         table.machines-info.view-table
-          tr
-            th Machines
-            th CPUs
-            th GPUs
-            th PPD
-            th Actions
+          thead
+            tr
+              th Machines
+              th CPUs
+              th GPUs
+              th PPD
+              th Actions
 
-          td(title="Active machine count")
-            | {{$machs.count.toLocaleString()}}
-          td(title="Active CPU count") {{$machs.active_cpus.toLocaleString()}}
-          td(title="Active GPU count") {{$machs.active_gpus.toLocaleString()}}
-          td(title="Current total Points Per Day")
-            | {{$machs.ppd.toLocaleString()}}
-          td
-            .machines-actions
-              Button(text="Fold All",
-              @click="$root.fold()", success, icon="play",
-              :disabled="$machs.is_empty",
-              title="Start folding on all machines")
+          tbody
+            tr
+              td(title="Active machine count")
+                | {{$machs.count.toLocaleString()}}
+              td(title="Active CPU count") {{$machs.active_cpus.toLocaleString()}}
+              td(title="Active GPU count") {{$machs.active_gpus.toLocaleString()}}
+              td(title="Current total Points Per Day")
+                | {{$machs.ppd.toLocaleString()}}
+              td
+                .machines-actions
+                  Button(text="Fold All",
+                  @click="$root.fold()", success, icon="play",
+                  :disabled="$machs.is_empty",
+                  title="Start folding on all machines")
 
-              Button(text="Pause All",
-                @click="$root.pause()", icon="pause",
-                :disabled="$machs.is_empty",
-                title="Pause folding on all machines")
+                  Button(text="Pause All",
+                    @click="$root.pause()", icon="pause",
+                    :disabled="$machs.is_empty",
+                    title="Pause folding on all machines")
 
     template(v-for="mach in machs")
       MachineView(v-if="!mach.is_hidden()", :mach="mach")

--- a/src/UnitDetailsView.vue
+++ b/src/UnitDetailsView.vue
@@ -120,21 +120,23 @@ export default {
       div(v-else-if="!credits.length") No credits logged
       template(v-else)
         table.view-table
-          tr
-            th Code
-            th User
-            th Team
-            th Credit
-            th Assigned
-            th Credited
+          thead
+            tr
+              th Code
+              th User
+              th Team
+              th Credit
+              th Assigned
+              th Credited
 
-          tr(v-for="credit in credits")
-            td.code {{credit.code}}
-            td.user {{credit.user}}
-            td.team {{credit.team}}
-            td.credit {{(credit.credit || 0).toLocaleString()}}
-            td.assigned {{credit.assign_time}}
-            td.credited {{credit.credit_time}}
+          tbody
+            tr(v-for="credit in credits")
+              td.code {{credit.code}}
+              td.user {{credit.user}}
+              td.team {{credit.team}}
+              td.credit {{(credit.credit || 0).toLocaleString()}}
+              td.assigned {{credit.assign_time}}
+              td.credited {{credit.credit_time}}
 
         p May included credits awarded to other users.
 

--- a/src/WUsView.vue
+++ b/src/WUsView.vue
@@ -152,73 +152,77 @@ export default {
       Filter Work Units to compute stats on different groups of units.
 
     table.view-table.wu-filters
-      tr
-        th Machine
-        th Project
-        th OS
-        th State
-        th Resources
-        th Within
-        th Complete
-        th.actions Actions
+      thead
+        tr
+          th Machine
+          th Project
+          th OS
+          th State
+          th Resources
+          th Within
+          th Complete
+          th.actions Actions
 
-      tr
-        td
-          select(v-model="filter.machine")
-            option(value="Any") Any
-            option(v-for="machine in machines", :value="machine") {{machine}}
+      tbody
+        tr
+          td
+            select(v-model="filter.machine")
+              option(value="Any") Any
+              option(v-for="machine in machines", :value="machine") {{machine}}
 
-        td
-          select(v-model="filter.project")
-            option(value="Any") Any
-            option(v-for="project in projects", :value="project") {{project}}
+          td
+            select(v-model="filter.project")
+              option(value="Any") Any
+              option(v-for="project in projects", :value="project") {{project}}
 
-        td
-          select(v-model="filter.os")
-            option(value="Any") Any
-            option(v-for="os in oses", :value="os") {{os}}
+          td
+            select(v-model="filter.os")
+              option(value="Any") Any
+              option(v-for="os in oses", :value="os") {{os}}
 
-        td
-          select(v-model="filter.state")
-            option(value="Any") Any
-            option(v-for="v in states", :value="v") {{v}}
+          td
+            select(v-model="filter.state")
+              option(value="Any") Any
+              option(v-for="v in states", :value="v") {{v}}
 
-        td
-          select(v-model="filter.resources")
-            option(value="Any") Any
-            option(v-for="r in resources", :value="r") {{r}}
+          td
+            select(v-model="filter.resources")
+              option(value="Any") Any
+              option(v-for="r in resources", :value="r") {{r}}
 
-        td(title="Only include units assigned within this number of days.")
-          input(v-model="filter.days", type=number, placeholder="days",
-            :class="{error: !isFinite(filter.days)}")
+          td(title="Only include units assigned within this number of days.")
+            input(v-model="filter.days", type=number, placeholder="days",
+              :class="{error: !isFinite(filter.days)}")
 
-        td(title="Only include completed units.")
-          input(type="checkbox", v-model="filter.complete")
+          td(title="Only include completed units.")
+            input(type="checkbox", v-model="filter.complete")
 
-        td.actions
-          span
-            Button.button-icon(icon="refresh", @click="reset",
-              title="Reset stats filter")
+          td.actions
+            span
+              Button.button-icon(icon="refresh", @click="reset",
+                title="Reset stats filter")
 
     p(v-if="!wus.length") No matching work units.
     table.view-table.wu-stats(v-else)
-      tr
-        th
-        th Average
-        th Min
-        th Max
+      thead
+        tr
+          th
+          th Average
+          th Min
+          th Max
 
-      tr(title="Time Per Frame.  Time to complete 1% of the unit.")
-        th TPF
-        td {{tpf_avg ? $util.time_interval(tpf_avg) : '???'}}
-        td {{tpf_min ? $util.time_interval(tpf_min) : '???'}}
-        td {{tpf_max ? $util.time_interval(tpf_max) : '???'}}
+      tbody
+        tr(title="Time Per Frame.  Time to complete 1% of the unit.")
+          th TPF
+          td {{tpf_avg ? $util.time_interval(tpf_avg) : '???'}}
+          td {{tpf_min ? $util.time_interval(tpf_min) : '???'}}
+          td {{tpf_max ? $util.time_interval(tpf_max) : '???'}}
 
-      tr(title="Points Per Day")
-        th PPD
-        td {{isFinite(ppd_avg) ? Math.round(ppd_avg).toLocaleString() : '???'}}
-        td {{isFinite(ppd_min) ? ppd_min.toLocaleString() : '???'}}
-        td {{isFinite(ppd_max) ? ppd_max.toLocaleString() : '???'}}
+        tr(title="Points Per Day")
+          th PPD
+          td {{isFinite(ppd_avg) ? Math.round(ppd_avg).toLocaleString() : '???'}}
+          td {{isFinite(ppd_min) ? ppd_min.toLocaleString() : '???'}}
+          td {{isFinite(ppd_max) ? ppd_max.toLocaleString() : '???'}}
 
     HelpBalloon.header-title(name="Recent Work Unit History"): p.
       A log of recent work WUs completed by your machines.


### PR DESCRIPTION
There were several complaints about the `tr` elements being directly inside the `table` element, without `thead` and `tbody` elements.
This commit adds the right elements where needed.

The only downside i noticed is that the **odd rows** style sometimes is too close to the **table header** (the machines table being the first example), so it needs to be checked.