### PR TITLE
Fix login using the enter button

### DIFF
--- a/src/LoginDialog.vue
+++ b/src/LoginDialog.vue
@@ -204,7 +204,7 @@ Dialog(:buttons="buttons", ref="dialog", width="40em")
             p: strong A passphrase is not the same as a passkey.
 
           input(v-model="passphrase", :type="show ? 'text' : 'password'",
-            @keyup.enter="do_login", name="password",
+            @keyup.enter="close('login')", name="password",
             autocomplete="current-password")
 
           .setting-actions


### PR DESCRIPTION
This commit re-enables the enter button to login after inserting the password.
The original method was removed in a previous commit and didn't work anymore.