### PR TITLE
feat: allow different resource configuration for idle

### DIFF
--- a/src/GroupSettings.vue
+++ b/src/GroupSettings.vue
@@ -290,7 +290,9 @@ fieldset.settings.view-panel(v-if="advanced")
 
     .setting
       > :first-child
-        width 9em
+        width 12em
+        min-width 12em
+        white-space normal
 
       select
         padding 0.25em 0.5em

--- a/src/SettingsView.vue
+++ b/src/SettingsView.vue
@@ -175,7 +175,7 @@ export default {
 
 
     get_group_config(config) {
-      let keys = ['on_idle', 'cpus', 'gpus', 'beta', 'key', 'cuda', 'hip']
+      let keys = ['on_idle', 'cpus', 'cpus_idle', 'gpus', 'gpus_idle', 'beta', 'key', 'cuda', 'hip']
       let copy = copy_keys(config, keys)
 
       copy.on_idle = !!copy.on_idle
@@ -190,6 +190,7 @@ export default {
         copy.keep_awake = !!config.keep_awake
       }
 
+      // Handle active/regular GPU config
       let config_gpus = config.gpus || {}
       copy.gpus = {}
       for (let id in this.available_gpus) {
@@ -200,6 +201,23 @@ export default {
       // Add GPUs which are enabled but not detected
       for (const [id, gpu] of Object.entries(config_gpus))
         if (gpu.enabled && !copy.gpus[id]) copy.gpus[id] = {enabled: true}
+
+      // Handle idle GPU config
+      if (copy.on_idle) {
+        let config_gpus_idle = config.gpus_idle || config_gpus
+        copy.cpus_idle = copy.cpus_idle ?? copy.cpus
+        copy.gpus_idle = {}
+        
+        for (let id in this.available_gpus) {
+          const enabled = (config_gpus_idle[id] || {}).enabled || false
+          copy.gpus_idle[id] = {enabled}
+        }
+
+        // Add GPUs which are enabled but not detected
+        for (const [id, gpu] of Object.entries(config_gpus_idle))
+          if (gpu.enabled && !copy.gpus_idle[id]) 
+            copy.gpus_idle[id] = {enabled: true}
+      }
 
       return copy
     },


### PR DESCRIPTION
The scenario I wanted to tackle:

When I am working on my PC I want to share a bit of my compute for the foldingathome project. But when I am idling I would like to share much more compute with the foldingathome project.

The frontend and backend would not allow this to be configured, so I added the configuration in both projects ([Backend PR](https://github.com/FoldingAtHome/fah-client-bastet/pull/398)).

I am normally used to angular and typescript, so I used AI to assist me with the task. The code looks correct to me. I tested it locally by adding a button in the frontend that would toggle a mock idle state in the backend.

The idea for this solution was adding 2 flags in the configuration that mimics the old behavior:

cpus_idle
gpus_idle

and 1 new flag that controls which resources are taken at idle time: 

different_idle_resources

```
{
  "on_idle":                  false,
  "different_idle_resources": false,
  "on_battery":               true,
  "keep_awake":               true,
  "paused":                   true,
  "finish":                   false,
  "beta":                     false,
  "cuda":                     true,
  "hip":                      true,
  "key":                      0,
  "cpus":                     0,
  "cpus_idle":                0,
  "gpus":                     {},
  "gpus_idle":                {}
}

```

<img width="1580" height="886" alt="image" src="https://github.com/user-attachments/assets/50ea19b4-d25c-4a93-85ba-5e0c6f991303" />

<img width="1641" height="393" alt="image" src="https://github.com/user-attachments/assets/6936db6c-6371-4fe8-b2e1-ff722f306600" />

