### PR TITLE
Fix incorrect Pug inline icon syntax

### DIFF
--- a/src/LoginDialog.vue
+++ b/src/LoginDialog.vue
@@ -198,7 +198,7 @@ Dialog(:buttons="buttons", ref="dialog", width="40em")
 
             p.
               When registering your Folding@home account you can generate
-              a secure passphrase by clicking the #[.fa.fa-refresh] icon.
+              a secure passphrase by clicking the #[span.fa.fa-refresh] icon.
               Make sure you save this passphrase somewhere safe, preferably in
               a password manager.
 

--- a/src/SettingsView.vue
+++ b/src/SettingsView.vue
@@ -324,7 +324,7 @@ Dialog.new-group-dialog(ref="new_group_dialog", buttons="Create")
             include a-z, 0-9, dashes (-) and dots (.).
           p.
             If the local machine is linked to another account you can link it to
-            this account by clicking on the #[.fa.fa-link] icon.
+            this account by clicking on the #[span.fa.fa-link] icon.
 
       .setting
         label Name


### PR DESCRIPTION
This PR corrects the inline icon syntax used in the Pug template.

Previously, the markup attempted to create an inline element using a class-only shorthand (.fa.fa-link), which is not valid in Pug when used inside interpolation. This caused the icon not to render as expected.

The syntax has been updated to:

```pug
#[span.fa.fa-link]
```

This ensures the element is correctly parsed and rendered, following Pug's requirement that inline interpolated elements must include an explicit tag name.

No functional changes other than fixing the icon rendering behavior.