### PR TITLE
Remove unused chart_mode reference to fix Vue render warning

### DIFF
--- a/src/ChartsDialog.vue
+++ b/src/ChartsDialog.vue
@@ -42,7 +42,7 @@ export default {
 <template lang="pug">
 Dialog.charts-dialog(ref="dialog", :buttons="['Ok']", width="90vw",
   height="90vh")
-  template(v-slot:header) Team {{chart_mode}} Chart
+  template(v-slot:header) Team Chart
   template(v-slot:body)
     .chart-controls
       .chart-modes


### PR DESCRIPTION
This PR removes the unused chart_mode reference that was being accessed during render but was not defined in the component instance.

Previously, the template attempted to use chart_mode, which caused Vue to emit the warning:

```console
[Vue warn]: Property "chart_mode" was accessed during render but is not defined on instance. 
```

Since the value is no longer defined or used elsewhere, the reference has been removed to eliminate the warning and clarify the component’s state.

Additionally, it seems the original intention may have been to display the chart mode and data source in the dialog title. However, since these options are already clearly presented via the existing radio controls, repeating them in the title may not be necessary. Removing the unused variables helps simplify the UI and avoid redundant information.