### PR TITLE
Hide groups with no resources on Machines tab

### DIFF
--- a/src/AccountAppearance.vue
+++ b/src/AccountAppearance.vue
@@ -81,6 +81,12 @@ fieldset.settings.view-panel
     HelpBalloon(name="Wide Display"): p Use full screen width.
     input(v-model="config.wide", type="checkbox")
 
+  .setting.hide-empty-groups-setting
+    HelpBalloon(name="Hide Empty Groups"): p.
+      Hides empty resource groups on the Machines view.
+      Empty resource groups will still display under machine settings.
+    input(v-model="config.hide_empty_groups", type="checkbox")
+
   .columns-setting
     HelpBalloon(name="Work Unit Columns"): p.
       Drag and drop columns to change their position and visibility.

--- a/src/AccountView.vue
+++ b/src/AccountView.vue
@@ -33,6 +33,7 @@ function copy_config(config = {}) {
     columns: (config.columns || []).concat([]),
     wide:    !!config.wide,
     compact: !!config.compact,
+    hide_empty_groups: !!config.hide_empty_groups,
   }
 }
 
@@ -208,5 +209,5 @@ Dialog(:buttons="confirm_dialog_buttons", ref="confirm_dialog")
         border-color var(--link-color)
 
   fieldset.settings .setting > label
-    width 7em
+    width 10em
 </style>

--- a/src/MachineGroup.vue
+++ b/src/MachineGroup.vue
@@ -43,6 +43,7 @@ export default {
     connected() {return this.mach.is_connected()},
     failed()    {return this.mach.get_group(this.group).failed},
     warn()      {return 1 < this.mach.get_group(this.group).failed_wus},
+    hide()      {return this.$adata.config.hide_empty_groups && !this.mach.has_resources(this.group)},
 
 
     status() {
@@ -71,7 +72,7 @@ export default {
 </script>
 
 <template lang="pug">
-.machine-group-header(v-if="header",
+.machine-group-header(v-if="header && !hide",
   :style="{'grid-column': `span ${columns.length + 1}`}",
   :class="{error: !!failed, warn: warn}")
   .group-name.header-subtitle

--- a/src/machine.js
+++ b/src/machine.js
@@ -87,6 +87,7 @@ class Machine {
     return s
   }
 
+  has_resources(group = '') {return this.get_config(group).cpus || this.get_gpus(group).length >= 1}
 
   get_conn() {return this.conn}
   set_conn(conn) {this.conn = conn}


### PR DESCRIPTION
This adds an account level appearance configuration option to hide any resource groups which do not have any resources assigned from the Machines view. Intended to save some screen real-estate on the main view for monitoring and controlling active work units.  Groups without resources assigned still show up in the Machine Settings view and still exist, they just get hidden on the Machines view.

1. Added a checkbox on the account level preferences for Appearance.
2. In order to support a longer checkbox name, made all checkboxes specifically in the Appearance preferences view have a min-width.
3. Split the `get_groups` method into two, one that gets all groups (same as original) and one that gets the filtered list of groups, excluding any that have no resource assignment.  Dynamically chose which version to call based on the user preference.
4. In the case where there is only one group with resources assigned, I set it such that if the only assigned group has a name it will still show the resource group header, since the name may have meaning.  So only if the one group with resources is the default group will the logic not show the group name header row. 