### PR TITLE
Prevent crash loading user/team PPD history from browser cache

### DIFF
--- a/src/subscriber.js
+++ b/src/subscriber.js
@@ -73,6 +73,7 @@ class Subscriber {
 
 
   async __cache_load() {
+    const startTime = performance.now()
     this.cache = await caches.open('fah-' + this.ref)
 
     let data = []
@@ -83,11 +84,16 @@ class Subscriber {
       data.push([ts, entry])
     }
 
+    const loadedEntries = data.length
     // Sort the data descending in time
     data.sort((a, b) => b[0] < a[0])
     this.data = data.map(e => e[1])
     this._limit_data()
     this._notify(this.data)
+    const endTime = performance.now()
+    console.log("__cache_load for fah-" + this.ref + " took " +
+                (endTime - startTime) + " ms to load " +
+                loadedEntries + " entries")
   }
 
 

--- a/src/subscriber.js
+++ b/src/subscriber.js
@@ -76,11 +76,24 @@ class Subscriber {
     const startTime = performance.now()
     this.cache = await caches.open('fah-' + this.ref)
 
+    const keys = await this.cache.keys()
+    if (keys.length < 1) return
+    const pageSize = 2000
+    const pages = []
+    for (let i = 0; i < keys.length; i += pageSize) {
+      const page = keys.slice(i, i + pageSize)
+      pages.push(
+        Promise.all(page.map(key => this.cache.match(key)))
+          .then(responses =>
+            Promise.all(responses.filter(Boolean).map(r => r.json()))
+        )
+      )
+    }
+
+    const results = (await Promise.all(pages)).flat()
     let data = []
-    let responses = await this.cache.matchAll('/', {ignoreSearch: true})
-    for (let res of responses) {
-      let entry = await res.json()
-      let ts    = new Date(entry.time).getTime()
+    for (const entry of results) {
+      const ts = new Date(entry.time).getTime()
       data.push([ts, entry])
     }
 


### PR DESCRIPTION
I encountered the following JS crash when opening my account in a browser where the team and user PPD history data was stored in the browser cache (using Brave, but also happened on Edge).  Deleting the cache from the browser allows it to load once when it builds the cache, but then refreshing causes the crash when trying to load 10k records from the cache.
<img width="544" height="25" alt="image" src="https://github.com/user-attachments/assets/5e1cb047-0786-4859-bd17-f1661ee6a9ea" />

Googling the issue indicates that there is a fixed limit on how much data can be serialized in the query response for the `Cache.matchAll` method which throws this error if the result would be more than 10 MB.  This applies to Chromium based browsers from what I can find.  Other browsers may have a different limit.

To get around this issue I have implemented a paged load which is working on my system which crashes in the cache load otherwise.  Please note that `Cache.keys()` also has the same 10 MB query result restriction, so if key serialization gets this large it will start crashing again.  This is implemented as a minimal change (single method modified) that avoids the issue as I have encountered without reducing the max number of records in the cache.

This batching implementation uses concurrent page loading where each page is processed in two phases
1. Each key in the page is queried by calling `Cache.match(key)`
2. Once all keys in the page are loaded, the conversion to Json is performed.

Processing of each page is started immediately and then await all pages to finish processing.
Processing into the data array is subsequently done only when all pages have finished loading.

Performance can be adjusted by tweaking the `pageSize` value.  I chose 2k as it had reasonable performance without creating too many concurrent calls (max 5 for a full cache at current limit).  I see between 3.5 and 5 seconds to load a full cache (10k limit) using this method.  It was 6-8 seconds for the matchAll method after reducing the max cache size (9k limit) such that cache load didn't crash for my account.

Performance testing done on Brave browser with cache sizes ranging from 2000 to 10000 max entries.  Paging method was always faster than `matchAll` method for the same cache size.  Also tested on Edge, both to reproduce the original issue and the fix using the 2k chunk size.

I left the timing code in a separate commit so it can easily be dropped for merge.