### PR TITLE
Cache machine unit wrappers and fix project refresh bookkeeping

### DIFF
--- a/src/machine.js
+++ b/src/machine.js
@@ -37,9 +37,6 @@ class Machine {
     this.aid   = ctx.$account.data.id
     this.cache = ctx.$cache
     this.util  = ctx.$util
-    this._raw_units = []
-    this._units = []
-    this._units_by_raw = new WeakMap()
     this.state = reactive({
       id,
       name:      id,
@@ -103,33 +100,8 @@ class Machine {
 
 
   get_units() {
-    const raw_units = this.get_data().units || []
-
-    if (raw_units.length == this._raw_units.length) {
-      let unchanged = true
-
-      for (let i = 0; i < raw_units.length; i++)
-        if (raw_units[i] !== this._raw_units[i]) {
-          unchanged = false
-          break
-        }
-
-      if (unchanged) return this._units
-    }
-
-    this._units = raw_units.map(unit => {
-      let wrapped = this._units_by_raw.get(unit)
-
-      if (!wrapped) {
-        wrapped = new Unit(this.ctx, unit, this)
-        this._units_by_raw.set(unit, wrapped)
-      }
-
-      return wrapped
-    })
-
-    this._raw_units = raw_units.slice()
-    return this._units
+    return (this.get_data().units || []).map(
+      unit => new Unit(this.ctx, unit, this))
   }
 
 

--- a/src/machine.js
+++ b/src/machine.js
@@ -37,10 +37,14 @@ class Machine {
     this.aid   = ctx.$account.data.id
     this.cache = ctx.$cache
     this.util  = ctx.$util
+    this._raw_units = []
+    this._units = []
+    this._units_by_raw = new WeakMap()
     this.state = reactive({
       id,
       name:      id,
       connected: false,
+      last_connected: 0,
       data:      {}
     })
   }
@@ -99,8 +103,33 @@ class Machine {
 
 
   get_units() {
-    return (this.get_data().units || []).map(
-      unit => new Unit(this.ctx, unit, this))
+    const raw_units = this.get_data().units || []
+
+    if (raw_units.length == this._raw_units.length) {
+      let unchanged = true
+
+      for (let i = 0; i < raw_units.length; i++)
+        if (raw_units[i] !== this._raw_units[i]) {
+          unchanged = false
+          break
+        }
+
+      if (unchanged) return this._units
+    }
+
+    this._units = raw_units.map(unit => {
+      let wrapped = this._units_by_raw.get(unit)
+
+      if (!wrapped) {
+        wrapped = new Unit(this.ctx, unit, this)
+        this._units_by_raw.set(unit, wrapped)
+      }
+
+      return wrapped
+    })
+
+    this._raw_units = raw_units.slice()
+    return this._units
   }
 
 
@@ -136,7 +165,7 @@ class Machine {
 
   is_recently_connected() {
     return this.is_connected() ||
-      new Date().getTime() < this.last_connected + 5 * 60 * 1000
+      new Date().getTime() < this.state.last_connected + 5 * 60 * 1000
   }
 
 

--- a/src/machines.js
+++ b/src/machines.js
@@ -129,7 +129,7 @@ class Machines {
 
   active_unit_sum(fn) {
     return Array.from(this).reduce((sum, mach) => {
-      if (!mach.is_recently_connected) return sum
+      if (!mach.is_recently_connected()) return sum
 
       return mach.get_units().reduce((sum, unit) => {
         if (unit.state != 'RUN' && !unit.finish) return sum

--- a/src/projects.js
+++ b/src/projects.js
@@ -63,13 +63,8 @@ class Projects {
     projects = Object.keys(projects).sort()
 
     let changed = projects.length != this.state.ids.length
-
-    if (!changed)
-      for (let i = 0; i < projects.length; i++)
-        if (projects[i] != this.state.ids[i]) {
-          changed = true
-          break
-        }
+    for (let i = 0; i < projects.length && !changed; i++)
+      changed = projects[i] != this.state.ids[i]
 
     if (changed) {
       this.state.ids = projects

--- a/src/projects.js
+++ b/src/projects.js
@@ -35,6 +35,7 @@ class Projects {
     this.timeout = timeout
     this.state   = reactive({
       loading:     true,
+      ids:         [],
       in_progress: {},
       projects:    {},
     })
@@ -59,9 +60,18 @@ class Projects {
     for (let unit of this.ctx.$machs.get_units())
       if (unit.assign.project) projects[unit.project] = true
 
-    projects = Object.keys(projects)
+    projects = Object.keys(projects).sort()
 
-    if (projects != this.state.ids) {
+    let changed = projects.length != this.state.ids.length
+
+    if (!changed)
+      for (let i = 0; i < projects.length; i++)
+        if (projects[i] != this.state.ids[i]) {
+          changed = true
+          break
+        }
+
+    if (changed) {
       this.state.ids = projects
       this._trigger_update()
     }
@@ -83,7 +93,7 @@ class Projects {
 
     // Remove old projects
     for (let id of Object.keys(this.state.projects))
-      if (!id in this.state.ids) delete this.state.projects[id]
+      if (!this.state.ids.includes(id)) delete this.state.projects[id]
   }
 
 


### PR DESCRIPTION
Avoid rebuilding the same Unit wrappers on every scan so the machines view performs less redundant work when many clients are present. This also restores the recently-connected check in the PPD path, allowing disconnected machines to be skipped again.

Update project ID tracking to compare the actual ID list rather than relying on array identity, and clean up stale project entries with a correct membership check so that refreshes trigger only when the set of projects genuinely changes.
