### PR TITLE
Add a basic .github/ci.yml for CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ci:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
Add a basic CI pipeline to validate contributions at a minimum level and prevent unknown breaking behavior.

Pull request summary from GitHub Copilot:

> This pull request introduces a new GitHub Actions workflow for continuous integration (CI). The workflow is set up to run on pushes to the `main` branch and on pull requests, and it automates the process of building the project in a Node.js environment.
> 
> CI workflow setup:
> 
> * Added a `.github/workflows/ci.yml` file that defines a CI workflow to automatically check out the code, set up Node.js (version 20), install dependencies using `npm ci`, and build the project on every push to `main` and on pull requests.