### PR TITLE
Harden CI workflow to fix zizmor audit findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,17 +5,23 @@ on:
     branches: [main]
   pull_request:
 
+permissions: {}
+
 jobs:
   ci:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '20'
           cache: 'npm'


### PR DESCRIPTION
Pin actions to commit SHAs, restrict workflow permissions to read-only, and disable credential persistence on checkout.