### PR TITLE
Fix CI pipeline to support no-lockfile install, cc #286

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,17 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '20'
-          cache: 'npm'
+
+      - name: Cache node modules
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
This project does not include a lock file in the repository, so setup-node with npm cache mode fails during CI with: "Dependencies lock file is not found".

Switch to npm install and cache node_modules using package.json hash so CI can run without a lock file.

PR Summary from GitHub Copilot:

> This pull request updates the continuous integration workflow configuration to improve dependency caching and installation steps.
> 
> **CI workflow improvements:**
> 
> * Replaces the built-in Node.js `npm` cache with a custom cache step using `actions/cache@v5`, caching the `node_modules` directory based on the hash of `package.json` for more granular and persistent caching. (.github/workflows/ci.yml)
> * Switches the dependency installation command from `npm ci` to `npm install`, which may affect how dependencies are installed and cached. (.github/workflows/ci.yml)